### PR TITLE
Make header and pkgconfig installation optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,23 +109,31 @@ target_include_directories(enet PUBLIC
 )
 
 # Setup pkgconfig
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/enet.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/enet.pc
-  @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/enet.pc
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/enet-config.in
-  ${CMAKE_CURRENT_BINARY_DIR}/enet-config
-  @ONLY)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/enet-config
-  DESTINATION "${CMAKE_INSTALL_BINDIR}")
+option(ENET_INSTALL_PKGCONFIG "Install enet pkgconfig files" ON)
+mark_as_advanced(ENET_INSTALL_PKGCONFIG)
+if(ENET_INSTALL_PKGCONFIG)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/enet.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/enet.pc
+    @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/enet.pc
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/enet-config.in
+    ${CMAKE_CURRENT_BINARY_DIR}/enet-config
+    @ONLY)
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/enet-config
+    DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
 
-install(DIRECTORY include/enet
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-  FILES_MATCHING PATTERN "*.h"
-)
+option(ENET_INSTALL_HEADERS "Install enet header files" ON)
+mark_as_advanced(ENET_INSTALL_HEADERS)
+if(ENET_INSTALL_HEADERS)
+  install(DIRECTORY include/enet
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILES_MATCHING PATTERN "*.h"
+  )
+endif()
 install(TARGETS enet
   EXPORT enet-targets
   RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"


### PR DESCRIPTION
This allows superbuild projects that include an internal copy of
enet to omit the unwanted headers and pkgconfig files in their
installation.